### PR TITLE
Correct over optimization of pre-initialized variables (#6500)

### DIFF
--- a/Marlin/ubl_G29.cpp
+++ b/Marlin/ubl_G29.cpp
@@ -342,6 +342,7 @@
           break;            // No more invalid Mesh Points to populate
         }
         ubl.z_values[location.x_index][location.y_index] = NAN;
+        cnt++;
       }
       SERIAL_PROTOCOLLNPGM("Locations invalidated.\n");
     }

--- a/Marlin/ubl_motion.cpp
+++ b/Marlin/ubl_motion.cpp
@@ -250,8 +250,10 @@
     const float m = dy / dx,
                 c = start[Y_AXIS] - m * start[X_AXIS];
 
-    const bool inf_normalized_flag = NEAR_ZERO(on_axis_distance),
-               inf_m_flag = NEAR_ZERO(dx);
+    bool inf_normalized_flag, inf_m_flag; 
+
+    inf_normalized_flag = isinf(e_normalized_dist);
+    inf_m_flag = isinf(m);
 
     /**
      * This block handles vertical lines. These are lines that stay within the same
@@ -265,7 +267,7 @@
         const float next_mesh_line_y = LOGICAL_Y_POSITION(pgm_read_float(&(ubl.mesh_index_to_ypos[current_yi])));
 
         /**
-         * inf_m_flag? the slope of the line is infinite, we won't do the calculations
+         * if the slope of the line is infinite, we won't do the calculations
          * else, we know the next X is the same so we can recover and continue!
          * Calculate X at the next Y mesh line
          */


### PR DESCRIPTION
* Correct over optimization of pre-initialized variables

NEAR_ZERO() works most of the time...  But it leaves corner cases
uncovered.  We need to explicitly check if these variables are +/-
infinity.

* Correct over optimization of pre-initialized variables